### PR TITLE
Changed error field type in TaskInfo class

### DIFF
--- a/src/main/java/abbyy/cloudsdk/v2/client/models/TaskInfo.java
+++ b/src/main/java/abbyy/cloudsdk/v2/client/models/TaskInfo.java
@@ -47,7 +47,7 @@ public final class TaskInfo {
      * Description of the processing error. Specified only with
      * ProcessingFailed Task status
      */
-    private Error error;
+    private String error;
 
     /**
      * Number of files added to a Task
@@ -106,11 +106,11 @@ public final class TaskInfo {
         this.status = status;
     }
 
-    public Error getError() {
+    public String getError() {
         return error;
     }
 
-    public void setError(Error error) {
+    public void setError(String error) {
         this.error = error;
     }
 


### PR DESCRIPTION
Field _error_ in class _TaskInfo_ class was of type Error. It caused deserialization error, in case document processing was failed. Changing _error_ type to String solves the issue 