### PR TITLE
Remove resources definition in POM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,23 +68,6 @@
     </distributionManagement>
 
     <build>
-        <resources>
-            <resource>
-                <directory>src/main/java</directory>
-            </resource>
-            <resource>
-                <directory>src/main/resources</directory>
-            </resource>
-        </resources>
-        <testResources>
-            <testResource>
-                <directory>src/test/java</directory>
-            </testResource>
-            <testResource>
-                <directory>src/test/resources</directory>
-            </testResource>
-        </testResources>
-
         <plugins>
             <plugin>
                 <artifactId>maven-assembly-plugin</artifactId>


### PR DESCRIPTION
The <resource> block in POM has the effect of including all the sources into the main artifact jar (as v1.0.0 on Maven Central shows).
This is not a best practice: the main artifact should contain only compiled `.class` files while all the sources should be in a separate `-sources` artifact.